### PR TITLE
Strengthen tests to catch more `selectrows`/`reformat` issues

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJTestInterface"
 uuid = "72560011-54dd-4dc2-94f3-c5de45b75ecd"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.1.1"
+version = "0.2.0"
 
 [deps]
 MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"

--- a/test/test.jl
+++ b/test/test.jl
@@ -33,7 +33,7 @@ expected_report2 = (
             y;
             mod=@__MODULE__,
             level=2,
-            verbosity=0
+            verbosity=0,
         )
     @test isempty(fails)
     @test report[1] == expected_report1


### PR DESCRIPTION
We  should probably add unit tests for these, but in the meantime the strengthening of tests in this PR should do a reasonable job. 

Before merge:

- [x] Explore implications for existing MLJ interfaces 
- [x] Tag as breaking