### PR TITLE
Make sure `:transform` is tested for transformers

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 0.5%

--- a/src/attemptors.jl
+++ b/src/attemptors.jl
@@ -93,6 +93,9 @@ function operations(fitted_machine, data...; throw=false, verbosity=1)
         model = fitted_machine.model
         operations = String[]
         methods = MLJBase.implemented_methods(fitted_machine.model)
+        if model isa Static && !(:transform in methods)
+            push!(methods, :transform)
+        end 
         _, test = MLJBase.partition(1:MLJBase.nrows(first(data)), 0.5)
         if :predict in methods
             predict(fitted_machine, first(data))

--- a/test/attemptors.jl
+++ b/test/attemptors.jl
@@ -42,6 +42,12 @@ MLJBase.transform(::DummyStatic, _, x, y) = hcat(x, y)
 MLJBase.package_name(::Type{<:DummyStatic}) = "DummyPackage"
 MLJBase.load_path(::Type{<:DummyStatic}) = "DummyPackage.Some.Thing.Different"
 
+struct DummyStatic2 <: Static end
+MLJBase.transform(::DummyStatic2, _, x, y) = hcat(x, y)
+MLJBase.package_name(::Type{<:DummyStatic2}) = "DummyPackage"
+MLJBase.load_path(::Type{<:DummyStatic2}) = "DummyPackage.Some.Thing.Different"
+MLJBase.implemented_methods(::Type{<:DummyStatic2}) = Symbol[]
+
 struct SupervisedTransformer <: Deterministic end
 MLJBase.fit(::SupervisedTransformer, verbosity, X, y) = (42, nothing, nothing)
 MLJBase.predict(::SupervisedTransformer, _, Xnew) = fill(4.5, length(Xnew))
@@ -60,6 +66,11 @@ MLJBase.load_path(::Type{<:SupervisedTransformer}) =
     @test outcome == "✓"
 
     smach = machine(DummyStatic())
+    operations, outcome = MLJTestInterface.operations(smach, X, y)
+    @test operations == "transform"
+    @test outcome == "✓"
+
+    smach = machine(DummyStatic2())
     operations, outcome = MLJTestInterface.operations(smach, X, y)
     @test operations == "transform"
     @test outcome == "✓"


### PR DESCRIPTION
The fallback `implemented_methods` does not catch methods when the model has type parameters.