### PR TITLE
Relax subsampling

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJTestInterface"
 uuid = "72560011-54dd-4dc2-94f3-c5de45b75ecd"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.2.6"
+version = "0.2.7"
 
 [deps]
 MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"

--- a/Project.toml
+++ b/Project.toml
@@ -13,3 +13,12 @@ MLJBase = "0.20, 0.21, 1"
 Pkg = "<0.0.1, 1"
 Test = "<0.0.1, 1"
 julia = "1.6"
+
+[extras]
+MLJDecisionTreeInterface = "c6f25543-311c-4c74-83dc-3ea6d1015661"
+MLJModels = "d491faf4-2d78-11e9-2867-c94bc002c0b7"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["MLJDecisionTreeInterface", "MLJModels", "Pkg", "Test"]

--- a/src/attemptors.jl
+++ b/src/attemptors.jl
@@ -78,7 +78,7 @@ function fitted_machine(model, data...; throw=false, verbosity=1)
         mach = model isa Static ? machine(model) :
                                   machine(model, data...)
         fit!(mach, verbosity=-1)
-        train, _ = MLJBase.partition(1:MLJBase.nrows(first(data)), 0.5)
+        train = 1:MLJBase.nrows(first(data))
         model isa Static || fit!(mach, rows=train, verbosity=-1)
         model isa Static || fit!(mach, rows=:, verbosity=-1)
         MLJBase.report(mach)
@@ -93,7 +93,7 @@ function operations(fitted_machine, data...; throw=false, verbosity=1)
         model = fitted_machine.model
         operations = String[]
         methods = MLJBase.implemented_methods(fitted_machine.model)
-        _, test = MLJBase.partition(1:MLJBase.nrows(first(data)), 0.5)
+        _, test = MLJBase.partition(1:MLJBase.nrows(first(data)), 0.99)
         if :predict in methods
             predict(fitted_machine, first(data))
             model isa Static || predict(fitted_machine, rows=test)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,0 @@
-[deps]
-MLJDecisionTreeInterface = "c6f25543-311c-4c74-83dc-3ea6d1015661"
-MLJModels = "d491faf4-2d78-11e9-2867-c94bc002c0b7"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
For the binary data set included in this package, the subsampling performed in the "fitted_machine" test leaves out one of the classes. While we like models to handle missing classes, this is tested in the more extensive tests at MLJTestIntegration.jl and seems a bit strict for an "interface" test. This PR replaces the 50% subsample with a 100% subsample.

It also removes test/Project.toml and puts these into the main Project.toml. 